### PR TITLE
Consider '-nan' attribute value as a nan value

### DIFF
--- a/src/pydap/parsers/das.py
+++ b/src/pydap/parsers/das.py
@@ -83,7 +83,7 @@ class DASParser(SimpleParser):
 
             if type.lower() in ['string', 'url']:
                 value = str(value).strip('"')
-            elif value.lower() in ['nan', 'nan.']:
+            elif value.lower() in ['nan', 'nan.', '-nan']:
                 value = float('nan')
             else:
                 value = ast.literal_eval(value)


### PR DESCRIPTION
I encountered some EPIC-formatted data that contains '-nan' values in some attributes. This PR fixes a problem where pydap would raise a *** ValueError: malformed string Exception.